### PR TITLE
Fix stdio MCP transport: stop polluting stdout, annotate Context params

### DIFF
--- a/src/icloud_mcp/auth.py
+++ b/src/icloud_mcp/auth.py
@@ -12,48 +12,28 @@ class AuthenticationError(Exception):
 
 
 def get_credentials(context: Context) -> Tuple[str, str]:
-    """Extract iCloud credentials from HTTP headers."""
-    
-    # Get HTTP headers using FastMCP's dependency function
+    """Extract iCloud credentials from HTTP headers, falling back to env vars."""
+
     headers = get_http_headers()
-    print(f"[AUTH DEBUG] Headers retrieved: {list(headers.keys())}")
-    
-    # Extract credentials from headers
+
     email: Optional[str] = headers.get("x-apple-email") or headers.get("X-Apple-Email")
     password: Optional[str] = headers.get("x-apple-app-specific-password") or headers.get("X-Apple-App-Specific-Password")
-    
-    print(f"[AUTH DEBUG] Email from headers: {email}")
-    print(f"[AUTH DEBUG] Password from headers: {'***' if password else None}")
-    
-    # Fallback to environment variables
+
     if not email:
         email = config.FALLBACK_EMAIL
-        print(f"[AUTH DEBUG] Using fallback email: {email}")
     if not password:
         password = config.FALLBACK_PASSWORD
-        print(f"[AUTH DEBUG] Using fallback password: {'***' if password else None}")
 
-    # Validate credentials
     if not email or not password:
-        print(f"[AUTH DEBUG] AUTHENTICATION FAILED - email: {email}, password: {'***' if password else None}")
         raise AuthenticationError(
             "Authentication required. Provide credentials via headers "
             "(X-Apple-Email, X-Apple-App-Specific-Password) or environment variables "
             "(ICLOUD_EMAIL, ICLOUD_APP_SPECIFIC_PASSWORD)"
         )
 
-    print(f"[AUTH DEBUG] Authentication successful for email: {email}")
     return email, password
 
 
 def require_auth(context: Context) -> Tuple[str, str]:
     """Decorator-friendly authentication check."""
-    print("[AUTH DEBUG] ========== require_auth CALLED ==========")
-    print(f"[AUTH DEBUG] Context received: {context}")
-    try:
-        result = get_credentials(context)
-        print(f"[AUTH DEBUG] ========== require_auth SUCCESS ==========")
-        return result
-    except Exception as e:
-        print(f"[AUTH DEBUG] ========== require_auth FAILED: {e} ==========")
-        raise
+    return get_credentials(context)

--- a/src/icloud_mcp/contacts.py
+++ b/src/icloud_mcp/contacts.py
@@ -1,5 +1,6 @@
 """CardDAV tools for contacts management using direct HTTP/WebDAV requests."""
 
+import sys
 import requests
 from requests.auth import HTTPBasicAuth
 import vobject
@@ -123,7 +124,7 @@ def _fetch_all_vcards(session: requests.Session, addressbook_url: str) -> List[D
         response = session.request('REPORT', addressbook_url, data=query_body, headers={'Depth': '1'})
         response.raise_for_status()
     except Exception as e:
-        print(f"Error fetching vCards: {str(e)}")
+        print(f"Error fetching vCards: {str(e)}", file=sys.stderr)
         return []
     
     # Parse XML response
@@ -144,8 +145,8 @@ def _fetch_all_vcards(session: requests.Session, addressbook_url: str) -> List[D
                     'etag': etag_elem.text if etag_elem is not None else ''
                 })
     except Exception as e:
-        print(f"Error parsing vCards: {str(e)}")
-    
+        print(f"Error parsing vCards: {str(e)}", file=sys.stderr)
+
     return vcards
 
 
@@ -234,7 +235,7 @@ async def list_contacts(
                     count += 1
             
             except Exception as e:
-                print(f"Error parsing vCard: {str(e)}")
+                print(f"Error parsing vCard: {str(e)}", file=sys.stderr)
                 continue
         
         return result

--- a/src/icloud_mcp/server.py
+++ b/src/icloud_mcp/server.py
@@ -1,6 +1,6 @@
 """FastMCP server for iCloud integration."""
 
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
 from . import calendar, contacts, email as email_module
 from .auth import AuthenticationError
 
@@ -28,7 +28,7 @@ async def health_check(request):
 # ============================================================================
 
 @mcp.tool()
-async def calendar_list_calendars(context) -> list | dict:
+async def calendar_list_calendars(context: Context) -> list | dict:
     """
     List all available calendars.
 
@@ -44,7 +44,7 @@ async def calendar_list_calendars(context) -> list | dict:
 
 @mcp.tool()
 async def calendar_list_events(
-    context,
+    context: Context,
     calendar_id: str = None,
     start_date: str = None,
     end_date: str = None
@@ -67,7 +67,7 @@ async def calendar_list_events(
 
 @mcp.tool()
 async def calendar_create_event(
-    context,
+    context: Context,
     summary: str,
     start: str,
     end: str,
@@ -98,7 +98,7 @@ async def calendar_create_event(
 
 @mcp.tool()
 async def calendar_update_event(
-    context,
+    context: Context,
     event_id: str,
     summary: str = None,
     start: str = None,
@@ -128,7 +128,7 @@ async def calendar_update_event(
 
 
 @mcp.tool()
-async def calendar_delete_event(context, event_id: str) -> dict:
+async def calendar_delete_event(context: Context, event_id: str) -> dict:
     """
     Delete a calendar event.
 
@@ -145,7 +145,7 @@ async def calendar_delete_event(context, event_id: str) -> dict:
 
 @mcp.tool()
 async def calendar_search_events(
-    context,
+    context: Context,
     query: str,
     calendar_id: str = None,
     start_date: str = None,
@@ -173,7 +173,7 @@ async def calendar_search_events(
 # ============================================================================
 
 @mcp.tool()
-async def contacts_list(context, limit: int = None) -> list | dict:
+async def contacts_list(context: Context, limit: int = None) -> list | dict:
     """
     List all contacts.
 
@@ -189,7 +189,7 @@ async def contacts_list(context, limit: int = None) -> list | dict:
 
 
 @mcp.tool()
-async def contacts_get(context, contact_id: str) -> dict:
+async def contacts_get(context: Context, contact_id: str) -> dict:
     """
     Get a specific contact by ID.
 
@@ -206,7 +206,7 @@ async def contacts_get(context, contact_id: str) -> dict:
 
 @mcp.tool()
 async def contacts_create(
-    context,
+    context: Context,
     name: str,
     phones: list[str] = None,
     emails: list[str] = None,
@@ -235,7 +235,7 @@ async def contacts_create(
 
 @mcp.tool()
 async def contacts_update(
-    context,
+    context: Context,
     contact_id: str,
     name: str = None,
     phones: list[str] = None,
@@ -265,7 +265,7 @@ async def contacts_update(
 
 
 @mcp.tool()
-async def contacts_delete(context, contact_id: str) -> dict:
+async def contacts_delete(context: Context, contact_id: str) -> dict:
     """
     Delete a contact.
 
@@ -281,7 +281,7 @@ async def contacts_delete(context, contact_id: str) -> dict:
 
 
 @mcp.tool()
-async def contacts_search(context, query: str) -> list | dict:
+async def contacts_search(context: Context, query: str) -> list | dict:
     """
     Search for contacts by text query.
 
@@ -301,7 +301,7 @@ async def contacts_search(context, query: str) -> list | dict:
 # ============================================================================
 
 @mcp.tool()
-async def email_list_folders(context) -> list | dict:
+async def email_list_folders(context: Context) -> list | dict:
     """
     List all email folders/mailboxes.
 
@@ -317,7 +317,7 @@ async def email_list_folders(context) -> list | dict:
 
 @mcp.tool()
 async def email_list_messages(
-    context,
+    context: Context,
     folder: str = "INBOX",
     limit: int = 50,
     unread_only: bool = False
@@ -342,7 +342,7 @@ async def email_list_messages(
 
 @mcp.tool()
 async def email_get_message(
-    context,
+    context: Context,
     message_id: str,
     folder: str = "INBOX",
     include_body: bool = True,
@@ -367,7 +367,7 @@ async def email_get_message(
 
 @mcp.tool()
 async def email_get_messages(
-    context,
+    context: Context,
     message_ids: list[str],
     folder: str = "INBOX",
     include_body: bool = True,
@@ -392,7 +392,7 @@ async def email_get_messages(
 
 @mcp.tool()
 async def email_search(
-    context,
+    context: Context,
     query: str,
     folder: str = "INBOX",
     limit: int = 50
@@ -415,7 +415,7 @@ async def email_search(
 
 @mcp.tool()
 async def email_send(
-    context,
+    context: Context,
     to: str,
     subject: str,
     body: str,
@@ -444,7 +444,7 @@ async def email_send(
 
 @mcp.tool()
 async def email_move(
-    context,
+    context: Context,
     message_id: str,
     from_folder: str,
     to_folder: str
@@ -467,7 +467,7 @@ async def email_move(
 
 @mcp.tool()
 async def email_delete(
-    context,
+    context: Context,
     message_id: str,
     folder: str = "INBOX",
     permanent: bool = False
@@ -490,7 +490,7 @@ async def email_delete(
 
 @mcp.tool()
 async def email_mark_read(
-    context,
+    context: Context,
     message_id: str,
     folder: str = "INBOX"
 ) -> dict:
@@ -511,7 +511,7 @@ async def email_mark_read(
 
 @mcp.tool()
 async def email_mark_unread(
-    context,
+    context: Context,
     message_id: str,
     folder: str = "INBOX"
 ) -> dict:


### PR DESCRIPTION
Two related issues prevent the server from working over stdio transport — the path used by Claude Code (and other native MCP clients). Both stem from the package not having been exercised against current FastMCP / a stdio MCP client. With the changes in this PR FastMCP usage works end-to-end.

### Issue 1: `print()` to stdout corrupts the JSON-RPC stream

Over stdio, **stdout is the MCP JSON-RPC channel**, so using `print()` to `stdout` for debug messages corrupts the protocol and clients reject every message thereafter. There were 14 such print calls in `auth.py` and `contacts.py`.

**Fix:**
- `auth.py`: drop the `[AUTH DEBUG]` `print()` statements, which seem to be left over from credential debugging
- `contacts.py`: route existing error-logging prints to `sys.stderr` where they don't corrupt the RCP channel

### Issue 2: Tool `context` params not type-annotated, FastMCP 3.x rejects calls

Every tool was declared as `async def tool_name(context, ...)` — `context` untyped. FastMCP 3.x only auto-injects request context when the parameter is annotated as `Context`; otherwise it's treated as a required caller argument and every tool call fails with:
```
ValidationError: 1 validation error for call[tool_name]
context
  Missing required argument
```

**Fix:** add `Context` to the import and annotate every tool's `context` parameter. 22 signatures touched, no semantic change.

### Testing (complete)

- [x] `python -c "from icloud_mcp.server import mcp"` imports cleanly post-patch.
- [x] Manual stdio JSON-RPC handshake (`initialize` → `tools/list`) returns clean responses on stdout, FastMCP banner stays on stderr.
- [x] `tools/call` for `contacts_search` returns expected vCards end-to-end.
- [x] Verified through Claude Code's native MCP client (`claude mcp add icloud -- python run.py` + live tool call from a session).

## AI Disclosure

Patches authored interactively with [Claude Code](https://claude.com/claude-code).