### PR TITLE
feat: tool category filter, HTML rendering, console scripts, fix streamable-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,29 @@ SMTP_SERVER=smtp.mail.me.com
 MCP_SERVER_PORT=8000
 IMAP_PORT=993
 SMTP_PORT=587
+
+# Tool Categories (optional — defaults to all three)
+# Comma-separated subset of: calendar, contacts, mail (mail is an alias for email)
+# Tools whose category is not listed are removed from the registry at startup
+# and will not appear in list_tools or be callable. Empty / unset / all-invalid
+# values fall back to enabling every category.
+ICLOUD_ENABLED_CATEGORIES=calendar,contacts,mail
 ```
+
+### Tool Categories
+
+Tools are grouped by name prefix:
+
+| Category | Tool prefix | Tools |
+|---|---|---|
+| `calendar` | `calendar_` | List, create, update, delete, search calendar events; list calendars |
+| `contacts` | `contacts_` | List, get, create, update, delete, search contacts |
+| `email` (alias `mail`) | `email_` | List folders/messages, get, search, send, move, delete, mark read/unread |
+
+Set `ICLOUD_ENABLED_CATEGORIES` to a comma-separated subset to expose only
+those tools — useful when running multiple server instances backed by
+different Apple IDs and you want each instance scoped to a specific surface
+(e.g. one calendar-only instance, one mail-only instance).
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ SMTP_PORT=587
 # and will not appear in list_tools or be callable. Empty / unset / all-invalid
 # values fall back to enabling every category.
 ICLOUD_ENABLED_CATEGORIES=calendar,contacts,mail
+
+# HTML Rendering Mode for free-text fields (optional — defaults to markdown)
+# Calendar event description/location and contact notes/addresses can carry
+# embedded HTML (e.g. "Reynier Park<br>2803 Reynier Ave..."). Choose how the
+# server returns these fields:
+#   markdown — convert <br>, <a>, <b>, <i>, <ul>/<li> to Markdown (default,
+#              best LLM ergonomics, links survive as [text](url))
+#   strip    — drop tags, decode entities, plain text (smallest tokens)
+#   raw      — return verbatim, do not touch (lossless passthrough)
+# Email message bodies are NEVER rendered through this — IMAP exposes
+# text/html parts separately and the agent picks per-call.
+ICLOUD_HTML_MODE=markdown
 ```
 
 ### Tool Categories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[project.scripts]
+icloud-mcp = "icloud_mcp.server:run"
+icloud-mcp-http = "icloud_mcp.server:run_http"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",

--- a/run.py
+++ b/run.py
@@ -31,12 +31,15 @@ def main():
     # Import after parsing to allow --help without dependencies
     try:
         # Try installed package first (for Docker/production)
-        from icloud_mcp.server import mcp
+        from icloud_mcp.server import mcp, apply_category_filter
         from icloud_mcp.config import config
     except ImportError:
         # Fall back to development mode
-        from src.icloud_mcp.server import mcp
+        from src.icloud_mcp.server import mcp, apply_category_filter
         from src.icloud_mcp.config import config
+
+    enabled = apply_category_filter(mcp)
+    print(f"iCloud MCP categories enabled: {sorted(enabled)}", file=sys.stderr)
 
     if args.http:
         port = args.port or int(os.environ.get("PORT", config.MCP_SERVER_PORT))

--- a/src/icloud_mcp/calendar.py
+++ b/src/icloud_mcp/calendar.py
@@ -10,6 +10,7 @@ from email.mime.text import MIMEText
 from fastmcp import Context
 from .auth import require_auth
 from .config import config
+from .html_render import render as _render_html
 
 
 def _get_caldav_client(email: str, password: str) -> caldav.DAVClient:
@@ -251,11 +252,11 @@ async def list_events(
 
                     result.append({
                         "id": str(event.url),
-                        "summary": str(vevent.summary.value) if hasattr(vevent, 'summary') and vevent.summary else "",
-                        "description": str(vevent.description.value) if hasattr(vevent, 'description') and vevent.description else "",
+                        "summary": _render_html(str(vevent.summary.value)) if hasattr(vevent, 'summary') and vevent.summary else "",
+                        "description": _render_html(str(vevent.description.value)) if hasattr(vevent, 'description') and vevent.description else "",
                         "start": start_value,
                         "end": end_value,
-                        "location": str(vevent.location.value) if hasattr(vevent, 'location') and vevent.location else "",
+                        "location": _render_html(str(vevent.location.value)) if hasattr(vevent, 'location') and vevent.location else "",
                         "calendar": calendar.name or "Unknown",
                         "url": str(event.url)
                     })

--- a/src/icloud_mcp/contacts.py
+++ b/src/icloud_mcp/contacts.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional
 from fastmcp import Context
 from .auth import require_auth
 from .config import config
+from .html_render import render as _render_html
 import xml.etree.ElementTree as ET
 from urllib.parse import urljoin
 import uuid
@@ -203,31 +204,37 @@ async def list_contacts(
                 
                 # Extract name
                 if hasattr(vcard, 'fn') and vcard.fn and hasattr(vcard.fn, 'value'):
-                    contact["name"] = str(vcard.fn.value)
-                
+                    contact["name"] = _render_html(str(vcard.fn.value))
+
                 # Extract phone numbers
                 if hasattr(vcard, 'tel_list'):
                     for tel in vcard.tel_list:
                         if hasattr(tel, 'value') and tel.value:
                             contact["phones"].append(str(tel.value))
-                
+
                 # Extract emails
                 if hasattr(vcard, 'email_list'):
                     for em in vcard.email_list:
                         if hasattr(em, 'value') and em.value:
                             contact["emails"].append(str(em.value))
-                
-                # Extract addresses
+
+                # Extract addresses (free-text label component can contain HTML)
                 if hasattr(vcard, 'adr_list'):
                     for adr in vcard.adr_list:
                         if hasattr(adr, 'value'):
                             try:
                                 addr_str = str(adr.value) if adr.value else ""
                                 if addr_str:
-                                    contact["addresses"].append(addr_str)
+                                    contact["addresses"].append(_render_html(addr_str))
                             except Exception as _e:
                                 continue
-                
+
+                # Extract free-text notes (rich-text-prone field)
+                if hasattr(vcard, 'note') and vcard.note and hasattr(vcard.note, 'value'):
+                    note_str = _render_html(str(vcard.note.value))
+                    if note_str:
+                        contact["note"] = note_str
+
                 # Only add contact if it has a name or at least one other field
                 if contact["name"] or contact["phones"] or contact["emails"]:
                     result.append(contact)
@@ -264,30 +271,36 @@ async def get_contact(context: Context, contact_id: str) -> Dict[str, Any]:
         
         contact = {
             "id": contact_id,
-            "name": str(vcard.fn.value) if hasattr(vcard, 'fn') else "",
+            "name": _render_html(str(vcard.fn.value)) if hasattr(vcard, 'fn') else "",
             "phones": [],
             "emails": [],
             "addresses": [],
-            "organization": str(vcard.org.value[0]) if hasattr(vcard, 'org') and vcard.org.value else "",
-            "title": str(vcard.title.value) if hasattr(vcard, 'title') else "",
+            "organization": _render_html(str(vcard.org.value[0])) if hasattr(vcard, 'org') and vcard.org.value else "",
+            "title": _render_html(str(vcard.title.value)) if hasattr(vcard, 'title') else "",
             "url": contact_id
         }
-        
+
         # Extract phone numbers
         if hasattr(vcard, 'tel_list'):
             for tel in vcard.tel_list:
                 contact["phones"].append(str(tel.value))
-        
+
         # Extract emails
         if hasattr(vcard, 'email_list'):
             for em in vcard.email_list:
                 contact["emails"].append(str(em.value))
-        
+
         # Extract addresses
         if hasattr(vcard, 'adr_list'):
             for adr in vcard.adr_list:
-                contact["addresses"].append(str(adr.value))
-        
+                contact["addresses"].append(_render_html(str(adr.value)))
+
+        # Extract free-text notes (rich-text-prone field)
+        if hasattr(vcard, 'note') and vcard.note and hasattr(vcard.note, 'value'):
+            note_str = _render_html(str(vcard.note.value))
+            if note_str:
+                contact["note"] = note_str
+
         return contact
     
     except Exception as e:

--- a/src/icloud_mcp/html_render.py
+++ b/src/icloud_mcp/html_render.py
@@ -1,0 +1,179 @@
+"""HTML rendering for free-text iCloud fields.
+
+iCloud lets users paste rich-text into calendar event description /
+location fields and contact notes; the values come back through CalDAV
+/ CardDAV verbatim, including embedded HTML like ``<br>`` and ``<a>``.
+
+This module renders those values into a form chosen by the operator via
+the ``ICLOUD_HTML_MODE`` env var:
+
+* ``markdown`` (default) — convert common HTML to Markdown so links and
+  emphasis survive while LLMs read it natively. ``<br>`` → newline,
+  ``<a href="x">y</a>`` → ``[y](x)``, ``<b>``/``<strong>`` → ``**…**``,
+  ``<i>``/``<em>`` → ``*…*``, ``<li>`` → ``- ``.
+* ``strip`` — drop all tags, decode entities, collapse whitespace. Smaller
+  token footprint; loses link URLs.
+* ``raw`` — return the value untouched. Lossless passthrough.
+
+Email message bodies are *not* rendered through this module — the IMAP
+side already exposes ``text`` and ``html`` parts separately, and the
+agent picks per-call.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Optional
+
+
+_MODE_ENV_VAR = "ICLOUD_HTML_MODE"
+_VALID_MODES = ("markdown", "strip", "raw")
+_DEFAULT_MODE = "markdown"
+
+
+def get_mode() -> str:
+    """Resolve the active render mode from env, falling back to markdown.
+
+    Unknown / empty values fall through to the default rather than raising —
+    operator typos shouldn't break the server.
+    """
+    raw = (os.environ.get(_MODE_ENV_VAR) or "").strip().lower()
+    return raw if raw in _VALID_MODES else _DEFAULT_MODE
+
+
+def _looks_like_html(value: str) -> bool:
+    """Cheap pre-check so plain-text fields skip the parser entirely.
+
+    Trips on common tag patterns and entity references; false positives
+    are harmless (the renderers are idempotent on plain text).
+    """
+    if not value:
+        return False
+    return ("<" in value and ">" in value) or "&" in value
+
+
+class _MarkdownRenderer(HTMLParser):
+    """Convert a subset of HTML to Markdown in a single pass.
+
+    Unknown tags are dropped (their inner text is kept). Whitespace is
+    collapsed to single spaces; explicit ``<br>``/``<p>`` produce
+    newlines.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+        self._href_stack: list[Optional[str]] = []
+        self._list_stack: list[str] = []  # "ul" | "ol"
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        a = dict(attrs)
+        if tag == "br":
+            self._out.append("\n")
+        elif tag in ("p", "div"):
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+        elif tag in ("b", "strong"):
+            self._out.append("**")
+        elif tag in ("i", "em"):
+            self._out.append("*")
+        elif tag == "a":
+            self._href_stack.append(a.get("href"))
+            self._out.append("[")
+        elif tag in ("ul", "ol"):
+            self._list_stack.append(tag)
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+        elif tag == "li":
+            marker = "1. " if (self._list_stack and self._list_stack[-1] == "ol") else "- "
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+            self._out.append(marker)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("b", "strong"):
+            self._out.append("**")
+        elif tag in ("i", "em"):
+            self._out.append("*")
+        elif tag == "a":
+            href = self._href_stack.pop() if self._href_stack else None
+            self._out.append(f"]({href})" if href else "]")
+        elif tag in ("p", "div", "li"):
+            self._out.append("\n")
+        elif tag in ("ul", "ol"):
+            if self._list_stack:
+                self._list_stack.pop()
+            self._out.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(data)
+
+    def render(self, value: str) -> str:
+        self.feed(value)
+        self.close()
+        out = "".join(self._out)
+        # Collapse 3+ blank lines into 2; trim outer whitespace
+        out = re.sub(r"\n{3,}", "\n\n", out)
+        return out.strip()
+
+
+class _StripRenderer(HTMLParser):
+    """Drop tags, keep text, normalize whitespace."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        if tag in ("br", "p", "div", "li", "tr"):
+            self._out.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("p", "div", "li", "tr"):
+            self._out.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(data)
+
+    def render(self, value: str) -> str:
+        self.feed(value)
+        self.close()
+        out = "".join(self._out)
+        out = re.sub(r"[ \t]+", " ", out)
+        out = re.sub(r"\n{3,}", "\n\n", out)
+        return out.strip()
+
+
+def render(value: Optional[str], mode: Optional[str] = None) -> Optional[str]:
+    """Render a free-text field per the active mode.
+
+    Parameters
+    ----------
+    value:
+        The string to render, or ``None``. ``None`` and empty strings are
+        returned unchanged.
+    mode:
+        Override the env-var-driven mode. Mainly for tests.
+
+    Returns
+    -------
+    The rendered string, or ``value`` unchanged if mode is ``raw`` or the
+    input doesn't look like HTML at all.
+    """
+    if not value:
+        return value
+    active = mode or get_mode()
+    if active == "raw":
+        return value
+    if not _looks_like_html(value):
+        # Still unescape entities (&amp; etc.) even in plain-text-looking
+        # values, since they're cheap and fix common copy-paste artifacts.
+        return unescape(value)
+    if active == "markdown":
+        return _MarkdownRenderer().render(value)
+    if active == "strip":
+        return _StripRenderer().render(value)
+    return value

--- a/src/icloud_mcp/server.py
+++ b/src/icloud_mcp/server.py
@@ -531,18 +531,97 @@ async def email_mark_unread(
 
 
 # ============================================================================
+# Tool category filter
+# ============================================================================
+
+# Tool-name prefix → category. Categories are also the values accepted in the
+# ICLOUD_ENABLED_CATEGORIES env var. "mail" is accepted as an alias for "email".
+_CATEGORY_PREFIXES = {
+    "calendar": "calendar_",
+    "contacts": "contacts_",
+    "email": "email_",
+}
+_CATEGORY_ALIASES = {"mail": "email"}
+_ALL_CATEGORIES = frozenset(_CATEGORY_PREFIXES)
+
+
+def _resolve_enabled_categories(raw: str | None) -> frozenset[str]:
+    """Parse ICLOUD_ENABLED_CATEGORIES into a normalized category set.
+
+    Empty / unset → all categories enabled (preserves legacy behavior).
+    Unknown tokens are ignored (with no error) so a typo can't lock the
+    operator out of every tool — but at least one valid category must
+    resolve, otherwise we treat it as "all" too.
+    """
+    if not raw:
+        return _ALL_CATEGORIES
+    requested = {t.strip().lower() for t in raw.split(",") if t.strip()}
+    resolved = {_CATEGORY_ALIASES.get(t, t) for t in requested}
+    valid = resolved & _ALL_CATEGORIES
+    return frozenset(valid) if valid else _ALL_CATEGORIES
+
+
+def apply_category_filter(server: FastMCP, raw: str | None = None) -> frozenset[str]:
+    """Remove tools whose category is not in ICLOUD_ENABLED_CATEGORIES.
+
+    Returns the set of categories that remained enabled. Idempotent: a second
+    call with the same value finds no matching tools left to remove.
+    """
+    import os as _os
+    import asyncio as _asyncio
+
+    enabled = _resolve_enabled_categories(
+        raw if raw is not None else _os.environ.get("ICLOUD_ENABLED_CATEGORIES")
+    )
+    if enabled == _ALL_CATEGORIES:
+        return enabled
+
+    disabled_prefixes = tuple(
+        prefix for cat, prefix in _CATEGORY_PREFIXES.items() if cat not in enabled
+    )
+
+    # FastMCP exposes registered tools via async list_tools() on the local
+    # provider; removal is sync. Snapshot first, then mutate.
+    provider = server.local_provider
+    try:
+        tools = _asyncio.run(provider.list_tools())
+    except RuntimeError:
+        # Already inside an event loop (rare for startup paths but possible
+        # under embedding). Schedule on a fresh loop in a worker thread.
+        import threading
+        result: list = []
+        def _runner():
+            result.append(_asyncio.new_event_loop().run_until_complete(provider.list_tools()))
+        t = threading.Thread(target=_runner)
+        t.start()
+        t.join()
+        tools = result[0] if result else []
+
+    for tool in tools:
+        if tool.name.startswith(disabled_prefixes):
+            try:
+                provider.remove_tool(tool.name)
+            except KeyError:
+                pass
+
+    return enabled
+
+
+# ============================================================================
 # Server Entrypoint
 # ============================================================================
 
 def run():
     """Run the MCP server."""
     from .config import config as app_config
+    apply_category_filter(mcp)
     mcp.run(transport="stdio")
 
 
 def run_http():
     """Run the MCP server with HTTP transport."""
     from .config import config as app_config
+    apply_category_filter(mcp)
     mcp.run(transport="sse", port=app_config.MCP_SERVER_PORT)
 
 

--- a/src/icloud_mcp/server.py
+++ b/src/icloud_mcp/server.py
@@ -612,17 +612,24 @@ def apply_category_filter(server: FastMCP, raw: str | None = None) -> frozenset[
 # ============================================================================
 
 def run():
-    """Run the MCP server."""
-    from .config import config as app_config
+    """Run the MCP server with stdio transport."""
     apply_category_filter(mcp)
     mcp.run(transport="stdio")
 
 
 def run_http():
-    """Run the MCP server with HTTP transport."""
+    """Run the MCP server with Streamable HTTP transport.
+
+    Honors PORT (or MCP_SERVER_PORT) and HOST env vars. Defaults bind to
+    127.0.0.1 so the server is loopback-only unless the operator explicitly
+    sets HOST=0.0.0.0 for a containerized/exposed deployment.
+    """
+    import os as _os
     from .config import config as app_config
+    port = int(_os.environ.get("PORT", app_config.MCP_SERVER_PORT))
+    host = _os.environ.get("HOST", "127.0.0.1")
     apply_category_filter(mcp)
-    mcp.run(transport="sse", port=app_config.MCP_SERVER_PORT)
+    mcp.run(transport="http", host=host, port=port, path="/mcp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR bundles four small, related improvements that came out of deploying icloud-mcp at fleet scale (multiple Apple IDs scoped to specific surfaces, agents reading the data through LLMs). Each is its own commit if you'd prefer to cherry-pick or land them separately — happy to split into focused PRs.

## Commits

| | What |
|---|---|
| [`0f27835`](https://github.com/mike-tih/icloud-mcp/pull/11/commits/0f27835) | `ICLOUD_ENABLED_CATEGORIES` env var |
| [`c593e17`](https://github.com/mike-tih/icloud-mcp/pull/11/commits/c593e17) | Console scripts + fix `run_http()` transport / binding |
| [`1299f96`](https://github.com/mike-tih/icloud-mcp/pull/11/commits/1299f96) | `ICLOUD_HTML_MODE` for rich-text field rendering |

---

## 1. `ICLOUD_ENABLED_CATEGORIES`

Lets operators run multiple instances backed by different Apple IDs and scope each to a subset of `calendar`, `contacts`, `email` (alias `mail`). Tools whose category is not enabled are removed from the FastMCP local provider before `run()`, so they neither appear in `tools/list` nor are callable — server-side enforcement, not prompt-level.

```bash
ICLOUD_ENABLED_CATEGORIES=calendar,contacts  # mail tools won't be exposed
```

Empty / unset / all-invalid values fall back to all-on, so a typo cannot accidentally lock the operator out of every tool. Idempotent. Implementation lives in `apply_category_filter()` in `server.py`.

## 2. Console-script entry points

Adds `[project.scripts]` to `pyproject.toml`:
- `icloud-mcp` → stdio
- `icloud-mcp-http` → streamable-http

So consumers can do `uvx --from git+https://github.com/mike-tih/icloud-mcp icloud-mcp-http` instead of cloning the repo to call `run.py`. Useful for systemd-launched deployments.

## 3. Fix `run_http()`

Previously used `transport=\"sse\"` (deprecated SSE) and didn't pass a `host`, defaulting to bind `0.0.0.0`. This PR switches it to streamable-http and reads `PORT` / `HOST` from env, defaulting to `127.0.0.1` so the server is loopback-only unless explicitly opened up.

```python
def run_http():
    port = int(os.environ.get(\"PORT\", config.MCP_SERVER_PORT))
    host = os.environ.get(\"HOST\", \"127.0.0.1\")
    apply_category_filter(mcp)
    mcp.run(transport=\"http\", host=host, port=port, path=\"/mcp\")
```

## 4. `ICLOUD_HTML_MODE`

iCloud lets users paste HTML into calendar event description / location and contact notes; values come back through CalDAV / CardDAV verbatim. Real example from production:

```
\"location\": \"Reynier Park<br>2803 Reynier Ave, Los Angeles, CA 90034\"
```

LLM consumers struggle with this. Three modes, default `markdown`:

| Mode | The value above becomes |
|---|---|
| `markdown` (default) | `Reynier Park\\n2803 Reynier Ave, Los Angeles, CA 90034` (plus `<a href=x>y</a>` → `[y](x)`, `<b>` → `**`) |
| `strip` | Same newline conversion, link URLs lost |
| `raw` | Verbatim passthrough — current behavior |

Stdlib only — `html.parser.HTMLParser` + `html.unescape`, no new deps.

Applied to: calendar event summary/description/location (list + search), contact name/organization/title/addresses + a new `note` field (list + get_contact). Email message bodies are intentionally untouched — IMAP exposes `text` / `html` parts separately and the agent picks per-call.

---

## Validation

Running in production on a Linux host: per-Apple-ID systemd units, app-specific-password creds sourced from a secrets vault at exec time, agents reach the server via `127.0.0.1:<port>/mcp`. CalDAV PROPFIND handshake against `caldav.icloud.com` returns 207 Multi-Status; tool calls work end-to-end through Claude/spacebot agents; the HTML-rendered location field reads cleanly in chat.

Thanks for the project — it's the only icloud MCP I found that covers all three protocols in one server.