### PR TITLE
feat: ICLOUD_ENABLED_CATEGORIES + console scripts + fix streamable-http transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,29 @@ SMTP_SERVER=smtp.mail.me.com
 MCP_SERVER_PORT=8000
 IMAP_PORT=993
 SMTP_PORT=587
+
+# Tool Categories (optional — defaults to all three)
+# Comma-separated subset of: calendar, contacts, mail (mail is an alias for email)
+# Tools whose category is not listed are removed from the registry at startup
+# and will not appear in list_tools or be callable. Empty / unset / all-invalid
+# values fall back to enabling every category.
+ICLOUD_ENABLED_CATEGORIES=calendar,contacts,mail
 ```
+
+### Tool Categories
+
+Tools are grouped by name prefix:
+
+| Category | Tool prefix | Tools |
+|---|---|---|
+| `calendar` | `calendar_` | List, create, update, delete, search calendar events; list calendars |
+| `contacts` | `contacts_` | List, get, create, update, delete, search contacts |
+| `email` (alias `mail`) | `email_` | List folders/messages, get, search, send, move, delete, mark read/unread |
+
+Set `ICLOUD_ENABLED_CATEGORIES` to a comma-separated subset to expose only
+those tools — useful when running multiple server instances backed by
+different Apple IDs and you want each instance scoped to a specific surface
+(e.g. one calendar-only instance, one mail-only instance).
 
 ### Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[project.scripts]
+icloud-mcp = "icloud_mcp.server:run"
+icloud-mcp-http = "icloud_mcp.server:run_http"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",

--- a/run.py
+++ b/run.py
@@ -31,12 +31,15 @@ def main():
     # Import after parsing to allow --help without dependencies
     try:
         # Try installed package first (for Docker/production)
-        from icloud_mcp.server import mcp
+        from icloud_mcp.server import mcp, apply_category_filter
         from icloud_mcp.config import config
     except ImportError:
         # Fall back to development mode
-        from src.icloud_mcp.server import mcp
+        from src.icloud_mcp.server import mcp, apply_category_filter
         from src.icloud_mcp.config import config
+
+    enabled = apply_category_filter(mcp)
+    print(f"iCloud MCP categories enabled: {sorted(enabled)}", file=sys.stderr)
 
     if args.http:
         port = args.port or int(os.environ.get("PORT", config.MCP_SERVER_PORT))

--- a/src/icloud_mcp/server.py
+++ b/src/icloud_mcp/server.py
@@ -531,18 +531,97 @@ async def email_mark_unread(
 
 
 # ============================================================================
+# Tool category filter
+# ============================================================================
+
+# Tool-name prefix → category. Categories are also the values accepted in the
+# ICLOUD_ENABLED_CATEGORIES env var. "mail" is accepted as an alias for "email".
+_CATEGORY_PREFIXES = {
+    "calendar": "calendar_",
+    "contacts": "contacts_",
+    "email": "email_",
+}
+_CATEGORY_ALIASES = {"mail": "email"}
+_ALL_CATEGORIES = frozenset(_CATEGORY_PREFIXES)
+
+
+def _resolve_enabled_categories(raw: str | None) -> frozenset[str]:
+    """Parse ICLOUD_ENABLED_CATEGORIES into a normalized category set.
+
+    Empty / unset → all categories enabled (preserves legacy behavior).
+    Unknown tokens are ignored (with no error) so a typo can't lock the
+    operator out of every tool — but at least one valid category must
+    resolve, otherwise we treat it as "all" too.
+    """
+    if not raw:
+        return _ALL_CATEGORIES
+    requested = {t.strip().lower() for t in raw.split(",") if t.strip()}
+    resolved = {_CATEGORY_ALIASES.get(t, t) for t in requested}
+    valid = resolved & _ALL_CATEGORIES
+    return frozenset(valid) if valid else _ALL_CATEGORIES
+
+
+def apply_category_filter(server: FastMCP, raw: str | None = None) -> frozenset[str]:
+    """Remove tools whose category is not in ICLOUD_ENABLED_CATEGORIES.
+
+    Returns the set of categories that remained enabled. Idempotent: a second
+    call with the same value finds no matching tools left to remove.
+    """
+    import os as _os
+    import asyncio as _asyncio
+
+    enabled = _resolve_enabled_categories(
+        raw if raw is not None else _os.environ.get("ICLOUD_ENABLED_CATEGORIES")
+    )
+    if enabled == _ALL_CATEGORIES:
+        return enabled
+
+    disabled_prefixes = tuple(
+        prefix for cat, prefix in _CATEGORY_PREFIXES.items() if cat not in enabled
+    )
+
+    # FastMCP exposes registered tools via async list_tools() on the local
+    # provider; removal is sync. Snapshot first, then mutate.
+    provider = server.local_provider
+    try:
+        tools = _asyncio.run(provider.list_tools())
+    except RuntimeError:
+        # Already inside an event loop (rare for startup paths but possible
+        # under embedding). Schedule on a fresh loop in a worker thread.
+        import threading
+        result: list = []
+        def _runner():
+            result.append(_asyncio.new_event_loop().run_until_complete(provider.list_tools()))
+        t = threading.Thread(target=_runner)
+        t.start()
+        t.join()
+        tools = result[0] if result else []
+
+    for tool in tools:
+        if tool.name.startswith(disabled_prefixes):
+            try:
+                provider.remove_tool(tool.name)
+            except KeyError:
+                pass
+
+    return enabled
+
+
+# ============================================================================
 # Server Entrypoint
 # ============================================================================
 
 def run():
     """Run the MCP server."""
     from .config import config as app_config
+    apply_category_filter(mcp)
     mcp.run(transport="stdio")
 
 
 def run_http():
     """Run the MCP server with HTTP transport."""
     from .config import config as app_config
+    apply_category_filter(mcp)
     mcp.run(transport="sse", port=app_config.MCP_SERVER_PORT)
 
 

--- a/src/icloud_mcp/server.py
+++ b/src/icloud_mcp/server.py
@@ -612,17 +612,24 @@ def apply_category_filter(server: FastMCP, raw: str | None = None) -> frozenset[
 # ============================================================================
 
 def run():
-    """Run the MCP server."""
-    from .config import config as app_config
+    """Run the MCP server with stdio transport."""
     apply_category_filter(mcp)
     mcp.run(transport="stdio")
 
 
 def run_http():
-    """Run the MCP server with HTTP transport."""
+    """Run the MCP server with Streamable HTTP transport.
+
+    Honors PORT (or MCP_SERVER_PORT) and HOST env vars. Defaults bind to
+    127.0.0.1 so the server is loopback-only unless the operator explicitly
+    sets HOST=0.0.0.0 for a containerized/exposed deployment.
+    """
+    import os as _os
     from .config import config as app_config
+    port = int(_os.environ.get("PORT", app_config.MCP_SERVER_PORT))
+    host = _os.environ.get("HOST", "127.0.0.1")
     apply_category_filter(mcp)
-    mcp.run(transport="sse", port=app_config.MCP_SERVER_PORT)
+    mcp.run(transport="http", host=host, port=port, path="/mcp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two related improvements that came out of deploying icloud-mcp at fleet scale (multiple Apple IDs scoped to specific surfaces, agents reading the data through LLMs).

## Commits

- [`0f27835`](https://github.com/mike-tih/icloud-mcp/commit/0f27835) — `ICLOUD_ENABLED_CATEGORIES` env var
- [`a355765`](https://github.com/mike-tih/icloud-mcp/commit/a355765) — Console scripts + fix `run_http()` transport / binding

Happy to split further if you'd prefer.

## 1. `ICLOUD_ENABLED_CATEGORIES`

Lets operators run multiple instances backed by different Apple IDs and scope each to a subset of `calendar`, `contacts`, `email` (alias `mail`). Tools whose category is not enabled are removed from the FastMCP local provider before `run()`, so they neither appear in `tools/list` nor are callable — server-side enforcement, not prompt-level.

```bash
ICLOUD_ENABLED_CATEGORIES=calendar,contacts  # mail tools won't be exposed
```

Empty / unset / all-invalid values fall back to all-on, so a typo cannot accidentally lock the operator out of every tool. Idempotent. Implementation in `apply_category_filter()` in `server.py`.

## 2. Console-script entry points + `run_http()` fix

Adds `[project.scripts]` to `pyproject.toml`:
- `icloud-mcp` → stdio
- `icloud-mcp-http` → streamable-http

So consumers can do `uvx --from git+https://github.com/mike-tih/icloud-mcp icloud-mcp-http` instead of cloning the repo to call `run.py`.

Also fixes `run_http()` which previously used `transport="sse"` (deprecated SSE) and didn't pass a `host`, so it bound `0.0.0.0` by default. Switches to streamable-http and reads `PORT` / `HOST` from env, defaulting to `127.0.0.1` so the server is loopback-only unless explicitly opened up.

## Validation

Currently running in production: per-Apple-ID systemd units, app-specific-password creds sourced from a secrets vault at exec time, agents reach the server via `127.0.0.1:<port>/mcp`. CalDAV PROPFIND handshake against `caldav.icloud.com` returns 207 Multi-Status; tool calls work end-to-end through Claude/spacebot agents.

A separate PR for HTML rendering of rich-text fields is up at #N — independent of this one.

Thanks for the project — it's the only icloud MCP I found covering all three protocols in one server.