### PR TITLE
feat: ICLOUD_HTML_MODE for rich-text field rendering (markdown/strip/raw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ SMTP_SERVER=smtp.mail.me.com
 MCP_SERVER_PORT=8000
 IMAP_PORT=993
 SMTP_PORT=587
+
+# HTML Rendering Mode for free-text fields (optional — defaults to markdown)
+# Calendar event description/location and contact notes/addresses can carry
+# embedded HTML (e.g. "Reynier Park<br>2803 Reynier Ave..."). Choose how the
+# server returns these fields:
+#   markdown — convert <br>, <a>, <b>, <i>, <ul>/<li> to Markdown (default,
+#              best LLM ergonomics, links survive as [text](url))
+#   strip    — drop tags, decode entities, plain text (smallest tokens)
+#   raw      — return verbatim, do not touch (lossless passthrough)
+# Email message bodies are NEVER rendered through this — IMAP exposes
+# text/html parts separately and the agent picks per-call.
+ICLOUD_HTML_MODE=markdown
 ```
 
 ### Authentication

--- a/src/icloud_mcp/calendar.py
+++ b/src/icloud_mcp/calendar.py
@@ -10,6 +10,7 @@ from email.mime.text import MIMEText
 from fastmcp import Context
 from .auth import require_auth
 from .config import config
+from .html_render import render as _render_html
 
 
 def _get_caldav_client(email: str, password: str) -> caldav.DAVClient:
@@ -251,11 +252,11 @@ async def list_events(
 
                     result.append({
                         "id": str(event.url),
-                        "summary": str(vevent.summary.value) if hasattr(vevent, 'summary') and vevent.summary else "",
-                        "description": str(vevent.description.value) if hasattr(vevent, 'description') and vevent.description else "",
+                        "summary": _render_html(str(vevent.summary.value)) if hasattr(vevent, 'summary') and vevent.summary else "",
+                        "description": _render_html(str(vevent.description.value)) if hasattr(vevent, 'description') and vevent.description else "",
                         "start": start_value,
                         "end": end_value,
-                        "location": str(vevent.location.value) if hasattr(vevent, 'location') and vevent.location else "",
+                        "location": _render_html(str(vevent.location.value)) if hasattr(vevent, 'location') and vevent.location else "",
                         "calendar": calendar.name or "Unknown",
                         "url": str(event.url)
                     })

--- a/src/icloud_mcp/contacts.py
+++ b/src/icloud_mcp/contacts.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional
 from fastmcp import Context
 from .auth import require_auth
 from .config import config
+from .html_render import render as _render_html
 import xml.etree.ElementTree as ET
 from urllib.parse import urljoin
 import uuid
@@ -203,31 +204,37 @@ async def list_contacts(
                 
                 # Extract name
                 if hasattr(vcard, 'fn') and vcard.fn and hasattr(vcard.fn, 'value'):
-                    contact["name"] = str(vcard.fn.value)
-                
+                    contact["name"] = _render_html(str(vcard.fn.value))
+
                 # Extract phone numbers
                 if hasattr(vcard, 'tel_list'):
                     for tel in vcard.tel_list:
                         if hasattr(tel, 'value') and tel.value:
                             contact["phones"].append(str(tel.value))
-                
+
                 # Extract emails
                 if hasattr(vcard, 'email_list'):
                     for em in vcard.email_list:
                         if hasattr(em, 'value') and em.value:
                             contact["emails"].append(str(em.value))
-                
-                # Extract addresses
+
+                # Extract addresses (free-text label component can contain HTML)
                 if hasattr(vcard, 'adr_list'):
                     for adr in vcard.adr_list:
                         if hasattr(adr, 'value'):
                             try:
                                 addr_str = str(adr.value) if adr.value else ""
                                 if addr_str:
-                                    contact["addresses"].append(addr_str)
+                                    contact["addresses"].append(_render_html(addr_str))
                             except Exception as _e:
                                 continue
-                
+
+                # Extract free-text notes (rich-text-prone field)
+                if hasattr(vcard, 'note') and vcard.note and hasattr(vcard.note, 'value'):
+                    note_str = _render_html(str(vcard.note.value))
+                    if note_str:
+                        contact["note"] = note_str
+
                 # Only add contact if it has a name or at least one other field
                 if contact["name"] or contact["phones"] or contact["emails"]:
                     result.append(contact)
@@ -264,30 +271,36 @@ async def get_contact(context: Context, contact_id: str) -> Dict[str, Any]:
         
         contact = {
             "id": contact_id,
-            "name": str(vcard.fn.value) if hasattr(vcard, 'fn') else "",
+            "name": _render_html(str(vcard.fn.value)) if hasattr(vcard, 'fn') else "",
             "phones": [],
             "emails": [],
             "addresses": [],
-            "organization": str(vcard.org.value[0]) if hasattr(vcard, 'org') and vcard.org.value else "",
-            "title": str(vcard.title.value) if hasattr(vcard, 'title') else "",
+            "organization": _render_html(str(vcard.org.value[0])) if hasattr(vcard, 'org') and vcard.org.value else "",
+            "title": _render_html(str(vcard.title.value)) if hasattr(vcard, 'title') else "",
             "url": contact_id
         }
-        
+
         # Extract phone numbers
         if hasattr(vcard, 'tel_list'):
             for tel in vcard.tel_list:
                 contact["phones"].append(str(tel.value))
-        
+
         # Extract emails
         if hasattr(vcard, 'email_list'):
             for em in vcard.email_list:
                 contact["emails"].append(str(em.value))
-        
+
         # Extract addresses
         if hasattr(vcard, 'adr_list'):
             for adr in vcard.adr_list:
-                contact["addresses"].append(str(adr.value))
-        
+                contact["addresses"].append(_render_html(str(adr.value)))
+
+        # Extract free-text notes (rich-text-prone field)
+        if hasattr(vcard, 'note') and vcard.note and hasattr(vcard.note, 'value'):
+            note_str = _render_html(str(vcard.note.value))
+            if note_str:
+                contact["note"] = note_str
+
         return contact
     
     except Exception as e:

--- a/src/icloud_mcp/html_render.py
+++ b/src/icloud_mcp/html_render.py
@@ -1,0 +1,179 @@
+"""HTML rendering for free-text iCloud fields.
+
+iCloud lets users paste rich-text into calendar event description /
+location fields and contact notes; the values come back through CalDAV
+/ CardDAV verbatim, including embedded HTML like ``<br>`` and ``<a>``.
+
+This module renders those values into a form chosen by the operator via
+the ``ICLOUD_HTML_MODE`` env var:
+
+* ``markdown`` (default) — convert common HTML to Markdown so links and
+  emphasis survive while LLMs read it natively. ``<br>`` → newline,
+  ``<a href="x">y</a>`` → ``[y](x)``, ``<b>``/``<strong>`` → ``**…**``,
+  ``<i>``/``<em>`` → ``*…*``, ``<li>`` → ``- ``.
+* ``strip`` — drop all tags, decode entities, collapse whitespace. Smaller
+  token footprint; loses link URLs.
+* ``raw`` — return the value untouched. Lossless passthrough.
+
+Email message bodies are *not* rendered through this module — the IMAP
+side already exposes ``text`` and ``html`` parts separately, and the
+agent picks per-call.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Optional
+
+
+_MODE_ENV_VAR = "ICLOUD_HTML_MODE"
+_VALID_MODES = ("markdown", "strip", "raw")
+_DEFAULT_MODE = "markdown"
+
+
+def get_mode() -> str:
+    """Resolve the active render mode from env, falling back to markdown.
+
+    Unknown / empty values fall through to the default rather than raising —
+    operator typos shouldn't break the server.
+    """
+    raw = (os.environ.get(_MODE_ENV_VAR) or "").strip().lower()
+    return raw if raw in _VALID_MODES else _DEFAULT_MODE
+
+
+def _looks_like_html(value: str) -> bool:
+    """Cheap pre-check so plain-text fields skip the parser entirely.
+
+    Trips on common tag patterns and entity references; false positives
+    are harmless (the renderers are idempotent on plain text).
+    """
+    if not value:
+        return False
+    return ("<" in value and ">" in value) or "&" in value
+
+
+class _MarkdownRenderer(HTMLParser):
+    """Convert a subset of HTML to Markdown in a single pass.
+
+    Unknown tags are dropped (their inner text is kept). Whitespace is
+    collapsed to single spaces; explicit ``<br>``/``<p>`` produce
+    newlines.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+        self._href_stack: list[Optional[str]] = []
+        self._list_stack: list[str] = []  # "ul" | "ol"
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        a = dict(attrs)
+        if tag == "br":
+            self._out.append("\n")
+        elif tag in ("p", "div"):
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+        elif tag in ("b", "strong"):
+            self._out.append("**")
+        elif tag in ("i", "em"):
+            self._out.append("*")
+        elif tag == "a":
+            self._href_stack.append(a.get("href"))
+            self._out.append("[")
+        elif tag in ("ul", "ol"):
+            self._list_stack.append(tag)
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+        elif tag == "li":
+            marker = "1. " if (self._list_stack and self._list_stack[-1] == "ol") else "- "
+            if self._out and not self._out[-1].endswith("\n"):
+                self._out.append("\n")
+            self._out.append(marker)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("b", "strong"):
+            self._out.append("**")
+        elif tag in ("i", "em"):
+            self._out.append("*")
+        elif tag == "a":
+            href = self._href_stack.pop() if self._href_stack else None
+            self._out.append(f"]({href})" if href else "]")
+        elif tag in ("p", "div", "li"):
+            self._out.append("\n")
+        elif tag in ("ul", "ol"):
+            if self._list_stack:
+                self._list_stack.pop()
+            self._out.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(data)
+
+    def render(self, value: str) -> str:
+        self.feed(value)
+        self.close()
+        out = "".join(self._out)
+        # Collapse 3+ blank lines into 2; trim outer whitespace
+        out = re.sub(r"\n{3,}", "\n\n", out)
+        return out.strip()
+
+
+class _StripRenderer(HTMLParser):
+    """Drop tags, keep text, normalize whitespace."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        if tag in ("br", "p", "div", "li", "tr"):
+            self._out.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("p", "div", "li", "tr"):
+            self._out.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        self._out.append(data)
+
+    def render(self, value: str) -> str:
+        self.feed(value)
+        self.close()
+        out = "".join(self._out)
+        out = re.sub(r"[ \t]+", " ", out)
+        out = re.sub(r"\n{3,}", "\n\n", out)
+        return out.strip()
+
+
+def render(value: Optional[str], mode: Optional[str] = None) -> Optional[str]:
+    """Render a free-text field per the active mode.
+
+    Parameters
+    ----------
+    value:
+        The string to render, or ``None``. ``None`` and empty strings are
+        returned unchanged.
+    mode:
+        Override the env-var-driven mode. Mainly for tests.
+
+    Returns
+    -------
+    The rendered string, or ``value`` unchanged if mode is ``raw`` or the
+    input doesn't look like HTML at all.
+    """
+    if not value:
+        return value
+    active = mode or get_mode()
+    if active == "raw":
+        return value
+    if not _looks_like_html(value):
+        # Still unescape entities (&amp; etc.) even in plain-text-looking
+        # values, since they're cheap and fix common copy-paste artifacts.
+        return unescape(value)
+    if active == "markdown":
+        return _MarkdownRenderer().render(value)
+    if active == "strip":
+        return _StripRenderer().render(value)
+    return value


### PR DESCRIPTION
Adds `ICLOUD_HTML_MODE` so operators can choose how the server returns rich-text fields that iCloud carries through verbatim from CalDAV / CardDAV.

This PR is independent of the category-filter PR (#N) — they touch different files and can land in either order.

## Why

iCloud lets users paste HTML into calendar event description / location and contact notes; the values come back with embedded `<br>`, `<a>`, `<b>`, etc. Real example I hit yesterday:

```
"location": "Reynier Park<br>2803 Reynier Ave, Los Angeles, CA 90034"
```

LLM consumers (the use case I care about) struggle with this — adds noise to context windows and obscures the actual structure of the data.

## What

```bash
ICLOUD_HTML_MODE=markdown    # default
ICLOUD_HTML_MODE=strip
ICLOUD_HTML_MODE=raw
```

| Mode | The value above becomes |
|---|---|
| `markdown` (default) | `Reynier Park\n2803 Reynier Ave, Los Angeles, CA 90034` (plus `<a href="x">y</a>` → `[y](x)`, `<b>` → `**`, `<ul><li>` → `- `) |
| `strip` | Same newline-conversion, link URLs lost |
| `raw` | Verbatim passthrough — current behavior |

Default is `markdown` because it's the best LLM trade-off — links and emphasis survive while the model reads it natively. Unknown / empty modes fall back to `markdown` so a typo can't break the server.

## Scope

Applied to:
- Calendar: event `summary`, `description`, `location` in `calendar_list_events` and (transitively) `calendar_search_events`
- Contacts: `name`, `organization`, `title`, `addresses[]`, plus the new `note` field, in both `contacts_list` and `contacts_get`

NOT applied to:
- Email message bodies — IMAP already exposes `text` and `html` parts separately, agents pick per-call. Re-rendering would be lossy and confusing.
- Email subjects, addresses — already plain text per RFC 5322; touching them risks corrupting punycode/UTF-7.
- Phone numbers, email addresses — never HTML.
- Anything in the write/update path — only the read responses are rendered.

## Implementation

Stdlib only — `html.parser.HTMLParser` + `html.unescape`. No new dependencies. New module `icloud_mcp/html_render.py`. Plain-text fields skip the parser entirely via a cheap `<` / `>` / `&` pre-check, so the overhead is zero on plain values.

## Notes

- New `note` field on contact responses is additive — old consumers ignore unknown keys.
- Considered exposing the mode as a per-call tool parameter. Settled on env var only because (a) it's operator-controlled, matching `ICLOUD_ENABLED_CATEGORIES` from the other PR, and (b) every tool would have to grow a `format` arg, which bloats the schema for marginal benefit. Easy to add later if there's demand.